### PR TITLE
Matomo-Template für Clickskeks Cookie-Banner

### DIFF
--- a/src/Resources/contao/templates/analytics_matomo_clickskeks.html5
+++ b/src/Resources/contao/templates/analytics_matomo_clickskeks.html5
@@ -1,0 +1,30 @@
+<?php
+
+// To use this script, please fill in your Matomo site ID and Matomo URL below
+$MatomoSite = 0;
+$MatomoPath = '//www.example.com/matomo/';
+
+// DO NOT EDIT ANYTHING BELOW THIS LINE UNLESS YOU KNOW WHAT YOU ARE DOING!
+if ($MatomoSite > 0 && '//www.example.com/matomo/' != $MatomoPath && !BE_USER_LOGGED_IN && !$this->hasAuthenticatedBackendUser()): ?>
+
+    <script>
+        window.Clickskeks.setAllowedConfigChangedCallback(function(allowedConfig) {
+            if(allowedConfig.statistics === true ) {
+                var _paq = window._paq = window._paq || [];
+                _paq.push(['trackPageView']);
+                _paq.push(['enableLinkTracking']);
+                (function () {
+                    var u = '<?= $MatomoPath ?>';
+                    _paq.push(['setTrackerUrl', u + 'matomo.php']);
+                    _paq.push(['setSiteId', <?= $MatomoSite ?>]);
+                    var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+                    g.async = true;
+                    g.defer = true;
+                    g.src = u + 'matomo.js';
+                    s.parentNode.insertBefore(g, s);
+                })();
+            }
+        }, true);
+    </script>
+
+<?php endif; ?>


### PR DESCRIPTION
Ein extra Clickskeks Matomo-Template, damit das Tracking wirklich erst ausgeführt wird, sobald der User sein Einverständnis gegeben hat.